### PR TITLE
config: add rpctimeout command line argument

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,6 +29,9 @@ type lndConfig struct {
 	// MacaroonName is the name of the macaroon in macaroon dir to use.
 	MacaroonName string `long:"macaroonname" description:"The name of our macaroon in macaroon dir to use."`
 
+	// RPCTimeout is the timeout for rpc calls to lnd in seconds.
+	RPCTimeout int `long:"rpctimeout" description:"The timeout for rpc calls to lnd in seconds"`
+
 	// TLSPath is the path to the lnd TLS certificate.
 	TLSPath string `long:"tlspath" description:"Path to lnd tls certificate"`
 }
@@ -55,6 +58,7 @@ var defaultConfig = config{
 		Network:      "mainnet",
 		MacaroonDir:  defaultMacaroonDir,
 		MacaroonName: defaultMacaroon,
+		RPCTimeout: 30,
 	},
 }
 

--- a/lndmon.go
+++ b/lndmon.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	flags "github.com/jessevdk/go-flags"
 	"github.com/lightninglabs/lndclient"
@@ -44,6 +45,7 @@ func start() error {
 			CustomMacaroonPath: filepath.Join(
 				cfg.Lnd.MacaroonDir, cfg.Lnd.MacaroonName,
 			),
+			RPCTimeout: time.Duration(cfg.Lnd.RPCTimeout) * time.Second,
 			TLSPath: cfg.Lnd.TLSPath,
 			CheckVersion: &verrpc.Version{
 				AppMajor: 0,


### PR DESCRIPTION
This PR adds an option to set the [lndclient RPCTimeout](https://github.com/lightninglabs/lndclient/blob/75630fe714237f8b17275325f859f96c30a880ea/lnd_services.go#L151-L154) when initializing lndclient. This gives lndmon users the option to increase the timeout beyond the default 30 seconds in cases where the metrics take longer to return.

Note: If not specified, this argument defaults to 30 seconds, which is the lndclient default.

Additional context:
We use lndmon for our lnd nodes running in Kubernetes and get frequent timeouts due to latency specific to nodes running with a PostgreSQL backend. As such, it often takes longer than 30 seconds for lndmon to gather metrics resulting in our lndmon pods frequently going into a crashloop status. In [issue:78] it was suggested that this could be addressed, on the lndmon side, by increasing the lndclient timeout. This seems to be a good workaround for us so I wanted to present this PR for consideration.